### PR TITLE
Remove courier references and add default accounts

### DIFF
--- a/src/main/java/org/nbu/LogisticsCompanyApplication.java
+++ b/src/main/java/org/nbu/LogisticsCompanyApplication.java
@@ -19,8 +19,18 @@ public class LogisticsCompanyApplication implements CommandLineRunner {
     @Override
     public void run(String... args) throws Exception {
         {
-            User newOwner = new User("admin@mail.com", "Admin", "123456");
+            // Default owner account this account will be the only account capable of listing all
+            // tasks (for delivery), clients and employees. This should not be deleted.
+            User newOwner = new User("owner@mail.com", "Owner", "123456");
             userService.createOwner(newOwner);
+
+            // TODO: Delete this account is created so we can do logic with tasks
+            User newCustomer = new User("customer@mail.com","Customer","123456");
+            userService.createCustomer(newCustomer);
+
+            // TODO: Delete this account is created so we can do logic with tasks
+            User newEmployee = new User("employee@mail.com","Employee","123456");
+            userService.createCustomer(newEmployee);
         }
     }
 }

--- a/src/main/java/org/nbu/config/SecurityConfig.java
+++ b/src/main/java/org/nbu/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
         // TODO: extend the matchers with the new endpoints
         http.authorizeRequests().antMatchers("/register", "/", "/about", "/login", "/css/**", "/webjars/**").permitAll()
-                .antMatchers("/profile").hasAnyRole("EMPLOYEE","CUSTOMER","OWNER","COURIER")
+                .antMatchers("/profile").hasAnyRole("EMPLOYEE","CUSTOMER","OWNER")
                 .antMatchers("/users", "/addTask", "/offices", "/registerOffice").hasRole("OWNER")
-                .antMatchers("/registerCourier", "/registerOffice").hasAnyRole("EMPLOYEE", "OWNER")
+                .antMatchers("/registerOffice").hasAnyRole("OWNER")
                 .and().formLogin().loginPage("/login").permitAll()
                 .defaultSuccessUrl("/profile").and().logout().logoutSuccessUrl("/login");
     }

--- a/src/main/java/org/nbu/controllers/RegisterController.java
+++ b/src/main/java/org/nbu/controllers/RegisterController.java
@@ -27,8 +27,8 @@ public class RegisterController {
 
     /**
      * This is base the method which registers the user which can be employee or customer
-     * Where employee can register office and register couriers for the office
-     * Where customer can register tasks to be delivered in office from courier
+     * Where owner can register office
+     * Where customer can register tasks and assign them to office and employee
      */
     @PostMapping("/register")
     public String registerUser(@Valid User user, BindingResult bindingResult, Model model) {
@@ -53,27 +53,17 @@ public class RegisterController {
         return "views/success";
     }
 
-    @GetMapping("/registerCourier")
-    public String registerCourierForm(@Valid User user, BindingResult bindingResult, Model model) {
-        // TODO: implement only employee should register courier aka employ courier
-        return "";
-    }
-
-    @PostMapping("/registerCourier")
-    public String registerCourier(@Valid User user, BindingResult bindingResult, Model model) {
-        // TODO: implement only employee should register courier aka employ courier
-        return "";
-    }
-
     @GetMapping("/registerOffice")
     public String registerOfficeForm(@Valid User user, BindingResult bindingResult, Model model) {
-        // TODO: implement only employee should register office and assign couriers to the office
+        // TODO: implement to return registration view for office which should only
+        //  be accessible by the owner which can register office
         return "";
     }
 
     @PostMapping("/registerOffice")
     public String registerOffice(@Valid User user, BindingResult bindingResult, Model model) {
-        // TODO: implement only employee should register office and assign couriers to the office
+        // TODO: implement saving the office information from the form above
+        //  only owner should have access to this endpoint
         return "";
     }
 

--- a/src/main/java/org/nbu/controllers/TaskController.java
+++ b/src/main/java/org/nbu/controllers/TaskController.java
@@ -23,7 +23,7 @@ public class TaskController {
 
     @GetMapping("/addTask")
     public String taskForm(String email, Model model, HttpSession session) {
-        // TODO: extend so tasks are assigned to couriers from the customer which wants
+        // TODO: extend so tasks are assigned to employee from the customer which wants
         //  his order to be delivered
         session.setAttribute("email", email);
         model.addAttribute("task", new Task());
@@ -33,7 +33,7 @@ public class TaskController {
 
     @PostMapping("/addTask")
     public String addTask(@Valid Task task, BindingResult bindingResult, HttpSession session) {
-        // TODO: extend so tasks are assigned to couriers from the customer which wants
+        // TODO: extend so tasks are assigned to employee from the customer which wants
         //  his order to be delivered
         if (bindingResult.hasErrors()) {
             return "views/taskForm";
@@ -44,41 +44,41 @@ public class TaskController {
         return "redirect:/users";
     }
 
-    @GetMapping("/showCustomerTask")
+    @GetMapping("/customerTask")
     public String taskCustomerForm(String email, Model model, HttpSession session) {
         // TODO: implement with a form so the customer can request task for delivery
-        //  from a courier and office
+        //  from employee and office
         return "";
     }
 
-    @GetMapping("/showCustomerTasks")
-    public String showCustomerTasks(String email, Model model, HttpSession session) {
+    @GetMapping("/listCustomerTasks")
+    public String listCustomerTasks(String email, Model model, HttpSession session) {
         // TODO: implement so the customer can see all the requested deliveries
         return "";
     }
 
-    @PostMapping("/showCustomerTask")
+    @PostMapping("/customerTask")
     public String taskCustomer(String email, Model model, HttpSession session) {
         // TODO: implement with a form so the customer can request task for delivery
-        //  from a courier and office
+        //  from employee and office
         return "";
     }
 
-    @GetMapping("/showCourierTask")
-    public String taskCourierForm(String email, Model model, HttpSession session) {
-        // TODO: implement with a form so the courier can accept or decline a task
+    @GetMapping("/employeeTask")
+    public String taskEmployeeForm(String email, Model model, HttpSession session) {
+        // TODO: implement with a form so the employee can accept or decline a task
         //  for delivery from a customer
         return "";
     }
 
-    @GetMapping("/showCourierTasks")
-    public String showCourierTasks(String email, Model model, HttpSession session) {
-        // TODO: implement so the courier can list all requested tasks for deliveries from a customer
+    @GetMapping("/listEmployeeTasks")
+    public String listEmployeeTasks(String email, Model model, HttpSession session) {
+        // TODO: implement so the employee can list all requested tasks for deliveries
         return "";
     }
 
-    @PostMapping("/showCourierTask")
-    public String taskCourier(String email, Model model, HttpSession session) {
+    @PostMapping("/employeeTask")
+    public String taskEmployee(String email, Model model, HttpSession session) {
         // TODO: implement with a form so the courier can accept or decline a task
         //  for delivery from a customer
         return "";

--- a/src/main/java/org/nbu/entities/Role.java
+++ b/src/main/java/org/nbu/entities/Role.java
@@ -12,7 +12,7 @@ import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 
 /**
- * All user types are differentiated only by role. The role can be COURIER, EMPLOYEE and CUSTOMER
+ * All user types are differentiated only by role. The role can be CUSTOMER, EMPLOYEE and OWNER
  */
 @Entity
 @Setter

--- a/src/main/java/org/nbu/entities/Task.java
+++ b/src/main/java/org/nbu/entities/Task.java
@@ -16,7 +16,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 
 
 /**
- * This class represents a task for delivery between customer and courier.
+ * This class represents a task for delivery between customer and employee.
  */
 @Entity
 @Setter

--- a/src/main/java/org/nbu/entities/User.java
+++ b/src/main/java/org/nbu/entities/User.java
@@ -20,8 +20,8 @@ import org.hibernate.validator.constraints.Email;
 import org.hibernate.validator.constraints.NotEmpty;
 
 /**
- * All accounts are user type accounts. The difference between COURIER EMPLOYEE
- * and ADMIN is only in the role which can be specified by string for authorization purposes.
+ * All accounts are user type accounts. The difference between EMPLOYEE, CUSTOMER
+ * and OWNER is only in the role which can be specified by string for authorization purposes.
  */
 @Entity
 @Setter


### PR DESCRIPTION
Removing courier references as they are redundant as per the requirements
in the PDF in the repository. Now OWNER can list all users and tasks and
is the only account type which can register offices. CUSTOMER type users
will request from EMPLOYEE type user task for delivery. And the EMPLOYEE
should accept or decline the delivery task.

Default accounts are now added on startup so we escape the need for
registration forms if we want to update the logic with tasks creation.

Signed-off-by: Martin Dekov <mvdekov@gmail.com>